### PR TITLE
Updating build

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       # if we just run the unit tests then go doesn't compile the parts of the app that aren't covered by
       # unit tests; this forces it


### PR DESCRIPTION
Adjusting the build config so it goes 💚 

Current builds are complaining with
> go: gotest.tools/gotestsum@latest (in gotest.tools/gotestsum@v1.13.0): go.mod:3: invalid go version '1.24.0': must match format 1.23
