### PR TITLE
Embed Version into app

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -15,22 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Test'
     steps:
-
       - uses: actions/checkout@v6
-
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{env.GO_VERSION}}
-
-
       - name: Setup gotestsum
         run: go install gotest.tools/gotestsum@latest
-
       - name: Unit Tests
         run: gotestsum --format testname --junitfile ../unit-tests.xml
         working-directory: ./pkg
-
       - name: Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
         if: (success() || failure())

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   GO_VERSION: 1.21
+  APP_VERSION: 'v0.0.0-dev'
 jobs:
   
   test:
@@ -51,13 +52,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Determine Version from PR
+        if: github.event_name == 'pull_request'
+        id: pr_version
+        run: |
+          BRANCH_NAME=$(echo ${{ github.head_ref }} | tr '/' '-' | tr '_' '-')
+          CURRENT_VERSION=$(git describe --tags --abbrev=0 || echo "0.0.0")
+          APP_VERSION="${CURRENT_VERSION}-${BRANCH_NAME}"
+          echo "APP_VERSION=${APP_VERSION}"
+          echo "APP_VERSION=${APP_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Determine Version from Release
+        if: github.event_name == 'release'
+        id: release_version
+        run: |
+          echo "APP_VERSION=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version:  ${{env.GO_VERSION}}
-
-#      - name: Build binary
-#        run: go build -o bin/octodiff cmd/octodiff/main.go
+          
       - name: Build for ${{ matrix.goos }}/${{ matrix.goarch }}
         env:
           GOOS: ${{ matrix.goos }}
@@ -67,9 +82,9 @@ jobs:
           if [ "${{ matrix.goos }}" = "windows" ]; then
             OUTPUT_NAME="${OUTPUT_NAME}.exe"
           fi
-          go build -o build/${{ matrix.goos }}_${{ matrix.goarch }}/$OUTPUT_NAME  cmd/octodiff/main.go
+          go build -o build/${{ matrix.goos }}_${{ matrix.goarch }}/$OUTPUT_NAME -ldflags="-X 'main.version=${{ env.APP_VERSION }}'" ./cmd/octodiff/
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: octodiff-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: build/${{ matrix.goos }}_${{ matrix.goarch }}/
+          name: octodiff-${{ matrix.goos }}-${{ matrix.goarch }}.${{env.APP_VERSION}}
+          path: build/${{ matrix.goos }}_${{ matrix.goarch }}

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,29 +1,27 @@
+#  act -j build --input dryRun=true --artifact-server-path ./bin  # to test locally with act
 name: 'PR and Commit Validation'
 on:
   workflow_dispatch:
   push:
     paths-ignore:
       - '**.md'
-jobs:
-  validation:
-    name: 'PR and Commit Validation'
-    runs-on: ubuntu-latest
 
-    permissions: # https://github.com/dorny/test-reporter/issues/168
-      statuses: write
-      checks: write
+env:
+  GO_VERSION: 1.21
+jobs:
+  
+  test:
+    runs-on: ubuntu-latest
+    name: 'Test'
     steps:
+
       - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: ${{env.GO_VERSION}}
 
-      # if we just run the unit tests then go doesn't compile the parts of the app that aren't covered by
-      # unit tests; this forces it
-      - name: Build binary
-        run: go build -o bin/octodiff cmd/octodiff/main.go
 
       - name: Setup gotestsum
         run: go install gotest.tools/gotestsum@latest
@@ -34,8 +32,44 @@ jobs:
 
       - name: Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
-        if: success() || failure()
+        if: (success() || failure())
         with:
           name: Test Results
           path: '*-tests.xml'
           reporter: java-junit
+    
+  build:
+    runs-on: ubuntu-latest
+    name: 'Build'
+    needs: test
+    strategy:
+      matrix:
+        goos: [ linux, windows, darwin ]
+        goarch: [ amd64, arm64 ]
+        #goos: [  windows ]
+        #goarch: [ amd64 ]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version:  ${{env.GO_VERSION}}
+
+#      - name: Build binary
+#        run: go build -o bin/octodiff cmd/octodiff/main.go
+      - name: Build for ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          OUTPUT_NAME="octodiff"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            OUTPUT_NAME="${OUTPUT_NAME}.exe"
+          fi
+          go build -o build/${{ matrix.goos }}_${{ matrix.goarch }}/$OUTPUT_NAME  cmd/octodiff/main.go
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: octodiff-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/${{ matrix.goos }}_${{ matrix.goarch }}/

--- a/cmd/octodiff/main.go
+++ b/cmd/octodiff/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
-	"github.com/OctopusDeploy/go-octodiff/pkg/cmd/root"
 	"os"
+
+	"github.com/OctopusDeploy/go-octodiff/pkg/cmd/root"
 )
 
 func main() {
+
 	cmd := root.NewCmdRoot()
+	cmd.AddCommand(NewCmdVersion())
 
 	if err := cmd.Execute(); err != nil {
 		cmd.PrintErr(err)

--- a/cmd/octodiff/version.go
+++ b/cmd/octodiff/version.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "0.0.0-dev"
+)
+
+func NewCmdVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "version",
+		Long: "Reports the version of octodiff",
+		RunE: func(c *cobra.Command, args []string) error {
+			// pick up positional arguments if not explicitly specified using --basis-file and --signature-file
+			fmt.Printf("App Version: %s\n", version)
+
+			if buildInfo, ok := debug.ReadBuildInfo(); ok {
+				for _, setting := range buildInfo.Settings {
+					if setting.Key == "vcs.revision" {
+						fmt.Printf("Commit Hash: %s\n", setting.Value)
+					}
+					if setting.Key == "vcs.time" {
+						fmt.Printf("Build Time: %s\n", setting.Value)
+					}
+				}
+				fmt.Printf("Go Version: %s\n", buildInfo.GoVersion)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
As we build this tool we will want to version it when taking it as a dependency.
A handy part of this is ensuring that the app self-reports the version that it itself represents.

This PR 
* Generates a version in the build chain [using the git history](https://github.com/OctopusDeploy/go-octodiff/pull/17/files#diff-82ae300566a0a2c1d2f008964f378c8ea281173dfc2ba3296f72f4014f1f4cdfR49) we do do with other services
* Embeds this version into the tool during build
* Exposes a new `version` command that outputs the following information
```
> octodiff.exe version

App Version: v0.0.0-dev
Commit Hash: d4ede15db2f63f6f97654e18587b881b8404ea7a
Build Time: 2026-01-12T02:13:58Z
Go Version: go1.21.13
```


### Also....
While I was in there I tweaked the build configuration to spit out a bunch of different platform builds.
It probably could have been in a separate PR but felt fairly minor to include.